### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We got around this in the quickest dirtyest way we could. We might make it bette
 
 Clone this repo.
 
-You need the `cards` json from the waffle page. You can get it by inspecting the page, going to timeline and waiting until the page has finished loading. It's just `cards` not `cards.json`. Copy the response body.
+You need the `cards` json from the waffle page. You can get it by inspecting the page, going to Networks and waiting until the page has finished loading. It's just `cards` not `cards.json`. Copy the response body.
 
 ![an image of the inspector showing the payload](https://raw.githubusercontent.com/notionparallax/Waffle-printer/master/response.png)
 


### PR DESCRIPTION
I was testing this today and noticed cards.json was under Networks, not timeline. 

There's also an API: https://api.waffle.io/pathTo/yourBoard/cards
